### PR TITLE
Opting in container based travis builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
 .tox
+.cache
+*.py[cod]
+__pycache__
+*.egg
+*.egg-info

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: c
 
+# Setting sudo to false opts in to Travis-CI container-based builds.
+sudo: false
+
 os:
     - linux
     - osx
@@ -14,9 +17,9 @@ env:
     - PYTHON_VERSION=3.3
     - PYTHON_VERSION=3.4
 
-install:  
+install:
 
-    # We use the ci-helpers package from the Astropy project to set up conda 
+    # We use the ci-helpers package from the Astropy project to set up conda
     # with any requested dependencies above.
     - git clone git://github.com/astropy/ci-helpers.git
     - source ci-helpers/travis/setup_conda_$TRAVIS_OS_NAME.sh


### PR DESCRIPTION
Miniconda's default prefix changed recently causing all travis builds failing.

Also opted in the container based travis builds.
