### PR TITLE
Change exception to warning

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,10 @@
 0.4 (unreleased)
 ----------------
 
-- Add support for remote baseline images.
+- Add support for remote baseline images. [#18]
+
+- When providing two conflicting options, warn instead of raising an
+  exception. [#19]
 
 0.3 (2015-06-26)
 ----------------

--- a/pytest_mpl/plugin.py
+++ b/pytest_mpl/plugin.py
@@ -34,6 +34,7 @@ import os
 import sys
 import shutil
 import tempfile
+import warnings
 
 import pytest
 
@@ -66,14 +67,13 @@ def pytest_addoption(parser):
 
 def pytest_configure(config):
 
-    if config.getoption("--mpl-generate-path") is not None:
-        if config.getoption("--mpl-baseline-path") is not None:
-            raise ValueError("Can't set --mpl-baseline-path when generating reference images with --mpl-generate-path")
-
     if config.getoption("--mpl") or config.getoption("--mpl-generate-path") is not None:
 
         baseline_dir = config.getoption("--mpl-baseline-path")
         generate_dir = config.getoption("--mpl-generate-path")
+
+        if baseline_dir is not None and generate_dir is not None:
+            warnings.warn("Ignoring --mpl-baseline-path since --mpl-generate-path is set")
 
         if baseline_dir is not None:
             baseline_dir = os.path.abspath(baseline_dir)


### PR DESCRIPTION
When providing two conflicting options, warn instead of raising an exception because one option may be a default in setup.cfg and we don’t want the user to have to go and edit the setup.cfg file to generate images.